### PR TITLE
Feature 습관 관리 및 수정 페이지

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import store from './redux/store';
@@ -10,7 +10,7 @@ import Header from './components/common/Header';
 import Sidebar from './components/sidebar/Sidebar';
 import CreateNickname from './pages/CreateNickname';
 
-const CreateHabit = React.lazy(() => import('./pages/CreateHabit'));
+const CreateOrEditHabit = lazy(() => import('./pages/CreateHabit'));
 
 function App() {
   return (
@@ -29,7 +29,19 @@ function App() {
                   <Routes>
                     <Route
                       path='/my-habit/:nickname/new-habit'
-                      element={<CreateHabit />}
+                      element={
+                        <Suspense fallback={<div>Loading...</div>}>
+                          <CreateOrEditHabit isEdit={false} />
+                        </Suspense>
+                      }
+                    />
+                    <Route
+                      path='/edit-habit/:habitId'
+                      element={
+                        <Suspense fallback={<div>Loading...</div>}>
+                          <CreateOrEditHabit isEdit={true} />
+                        </Suspense>
+                      }
                     />
                     <Route path='/my-habit/:nickname' element={<MyHabit />} />
                     <Route path='/group/:groupId' element={<Group />} />

--- a/src/components/habits/HabitDetail/HabitDetail.js
+++ b/src/components/habits/HabitDetail/HabitDetail.js
@@ -5,12 +5,13 @@ import HabitTime from './HabitTime';
 import HabitDaysOfWeek from './HabitDaysOfWeek';
 import HabitSection from './HabitSection';
 import { useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import getUserIdFromToken from '../../../utils/getUserIdFromToken';
 import axios from 'axios';
 
 const HabitDetail = () => {
   const habitDetail = useSelector((state) => state.habit.habitDetail);
+  const location = useLocation();
 
   const currentUserId = getUserIdFromToken();
   const isCurrentUser = currentUserId === habitDetail.creator._id;
@@ -45,16 +46,23 @@ const HabitDetail = () => {
       <HabitDaysOfWeek doDay={habitDetail.doDay} />
 
       <WatcherActions habitDetail={habitDetail} />
-      {isCurrentUser && (
-        <div>
+      {location.pathname.startsWith('/my-habit') && isCurrentUser && (
+        <div className='flex justify-center mt-6 space-x-4'>
           <Link
             to={{
               pathname: `/edit-Habit/${habitDetail._id}`,
             }}
+            className='bg-green-bg w-32 h-8 rounded-xl flex items-center justify-center text-center text-white transition-all hover:bg-green-800 border-2'
           >
             수정
           </Link>
-          <button onClick={handleDelete}>삭제</button>
+
+          <button
+            onClick={handleDelete}
+            className='bg-transparent w-32 h-8 rounded-xl flex items-center justify-center text-center text-white transition-all hover:bg-red-500 border-2'
+          >
+            삭제
+          </button>
         </div>
       )}
     </div>

--- a/src/components/habits/HabitDetail/HabitDetail.js
+++ b/src/components/habits/HabitDetail/HabitDetail.js
@@ -6,15 +6,14 @@ import HabitDaysOfWeek from './HabitDaysOfWeek';
 import HabitSection from './HabitSection';
 import { useSelector } from 'react-redux';
 import { Link, useLocation } from 'react-router-dom';
-import getUserIdFromToken from '../../../utils/getUserIdFromToken';
+import isLoginUser from '../../../lib/isLoginUser';
 import axios from 'axios';
 
 const HabitDetail = () => {
   const habitDetail = useSelector((state) => state.habit.habitDetail);
   const location = useLocation();
 
-  const currentUserId = getUserIdFromToken();
-  const isCurrentUser = currentUserId === habitDetail.creator._id;
+  const isCurrentUser = isLoginUser(habitDetail.creator._id);
 
   const handleDelete = async () => {
     try {

--- a/src/components/habits/HabitDetail/HabitDetail.js
+++ b/src/components/habits/HabitDetail/HabitDetail.js
@@ -5,9 +5,28 @@ import HabitTime from './HabitTime';
 import HabitDaysOfWeek from './HabitDaysOfWeek';
 import HabitSection from './HabitSection';
 import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+import getUserIdFromToken from '../../../utils/getUserIdFromToken';
+import axios from 'axios';
 
 const HabitDetail = () => {
   const habitDetail = useSelector((state) => state.habit.habitDetail);
+
+  console.log(habitDetail);
+
+  const currentUserId = getUserIdFromToken();
+  const isCurrentUser = currentUserId === habitDetail.creator._id;
+
+  const handleDelete = async () => {
+    try {
+      await axios.delete(
+        `${process.env.REACT_APP_SERVER_DOMAIN}/api/habit/${habitDetail._id}`,
+      );
+      window.location.reload();
+    } catch (error) {
+      console.error('Habit deletion failed:', error);
+    }
+  };
 
   return (
     <div className='h-[calc(70vh-130px)] overflow-y-auto custom-scrollbar z-10 ml-4 mr-1.5 pr-1.5'>
@@ -28,6 +47,18 @@ const HabitDetail = () => {
       <HabitDaysOfWeek doDay={habitDetail.doDay} />
 
       <WatcherActions habitDetail={habitDetail} />
+      {isCurrentUser && (
+        <div>
+          <Link
+            to={{
+              pathname: `/edit-Habit/${habitDetail._id}`,
+            }}
+          >
+            수정
+          </Link>
+          <button onClick={handleDelete}>삭제</button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/habits/HabitDetail/HabitDetail.js
+++ b/src/components/habits/HabitDetail/HabitDetail.js
@@ -12,8 +12,6 @@ import axios from 'axios';
 const HabitDetail = () => {
   const habitDetail = useSelector((state) => state.habit.habitDetail);
 
-  console.log(habitDetail);
-
   const currentUserId = getUserIdFromToken();
   const isCurrentUser = currentUserId === habitDetail.creator._id;
 

--- a/src/components/habits/HabitDetail/HabitDetail.js
+++ b/src/components/habits/HabitDetail/HabitDetail.js
@@ -20,6 +20,7 @@ const HabitDetail = () => {
       await axios.delete(
         `${process.env.REACT_APP_SERVER_DOMAIN}/api/habit/${habitDetail._id}`,
       );
+
       window.location.reload();
     } catch (error) {
       console.error('Habit deletion failed:', error);

--- a/src/components/habits/HabitDetail/WatcherActions.js
+++ b/src/components/habits/HabitDetail/WatcherActions.js
@@ -112,7 +112,7 @@ const WatcherActions = ({ habitDetail }) => {
       )}
       {!shouldRenderButtons && isGroupShared && (
         <p className='text-center mb-4 text-dark-gray-txt'>
-          인증 탭을 확인하세요
+          인증 페이지를 확인하세요
         </p>
       )}
       {subscriptionError && <ErrorMessage message={subscriptionError} />}

--- a/src/components/habits/HabitDetail/WatcherActions.js
+++ b/src/components/habits/HabitDetail/WatcherActions.js
@@ -82,7 +82,7 @@ const WatcherActions = ({ habitDetail }) => {
               Watcher가 없습니다
             </p>
           ) : (
-            <div className='flex flex-wrap'>
+            <div className='flex flex-wrap justify-center'>
               {shouldRenderButtons &&
                 !isCurrentUserWatcher &&
                 !isCurrentUserCreator && (

--- a/src/components/habits/HabitDetail/WatcherActions.js
+++ b/src/components/habits/HabitDetail/WatcherActions.js
@@ -18,6 +18,9 @@ const WatcherActions = ({ habitDetail }) => {
   const [subscriptionError, setSubscriptionError] = useState(null);
   const currentUserId = getUserIdFromToken();
 
+  const shouldRenderButtons =
+    habitDetail.status === 'notTimeYet' || habitDetail.status === 'inProgress';
+
   const isCurrentUserCreator = habitDetail.creator?._id === currentUserId;
 
   const isCurrentUserWatcher = habitDetail.approvals?.some((approval) => {
@@ -80,19 +83,22 @@ const WatcherActions = ({ habitDetail }) => {
             </p>
           ) : (
             <div className='flex flex-wrap'>
-              {!isCurrentUserWatcher && !isCurrentUserCreator && (
-                <div className='m-2'>
-                  <WatcherButton
-                    isSubscribe={true}
-                    handleAction={handleSubscribe}
-                    className='w-12 h-12'
-                  />
-                </div>
-              )}
+              {shouldRenderButtons &&
+                !isCurrentUserWatcher &&
+                !isCurrentUserCreator && (
+                  <div className='m-2'>
+                    <WatcherButton
+                      isSubscribe={true}
+                      handleAction={handleSubscribe}
+                      className='w-12 h-12'
+                    />
+                  </div>
+                )}
               <WatcherList
                 sortedApprovals={sortedApprovals}
                 currentUserId={currentUserId}
                 handleUnsubscribe={handleUnsubscribe}
+                shouldRenderButtons={shouldRenderButtons}
               />
             </div>
           )}
@@ -102,6 +108,11 @@ const WatcherActions = ({ habitDetail }) => {
           비공개 습관이므로
           <br />
           Watcher가 없습니다
+        </p>
+      )}
+      {!shouldRenderButtons && isGroupShared && (
+        <p className='text-center mb-4 text-dark-gray-txt'>
+          인증 탭을 확인하세요
         </p>
       )}
       {subscriptionError && <ErrorMessage message={subscriptionError} />}

--- a/src/components/habits/HabitDetail/WatcherList.js
+++ b/src/components/habits/HabitDetail/WatcherList.js
@@ -1,7 +1,12 @@
 import { useState } from 'react';
 import WatcherButton from './WatcherButton';
 
-const WatcherList = ({ sortedApprovals, currentUserId, handleUnsubscribe }) => {
+const WatcherList = ({
+  sortedApprovals,
+  currentUserId,
+  handleUnsubscribe,
+  shouldRenderButtons,
+}) => {
   const [hoveredWatcher, setHoveredWatcher] = useState(null);
 
   const handleMouseEnter = (watcherId) => {
@@ -27,7 +32,8 @@ const WatcherList = ({ sortedApprovals, currentUserId, handleUnsubscribe }) => {
               src={approval.profileImageUrl}
               alt='Watcher profile'
             />
-            {hoveredWatcher === approval._id &&
+            {shouldRenderButtons &&
+              hoveredWatcher === approval._id &&
               approval._id === currentUserId && (
                 <WatcherButton
                   isSubscribe={false}

--- a/src/components/habits/Tabs.js
+++ b/src/components/habits/Tabs.js
@@ -1,19 +1,49 @@
+import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
 const Tabs = ({ handleViewDetail, handleViewVerfication }) => {
+  const [selectedTab, setSelectedTab] = useState('detail');
+  const location = useLocation();
+
+  useEffect(() => {
+    setSelectedTab('detail');
+  }, [location.pathname]);
+
+  const handleDetailClick = () => {
+    handleViewDetail();
+    setSelectedTab('detail');
+  };
+
+  const handleVerificationClick = () => {
+    handleViewVerfication();
+    setSelectedTab('verification');
+  };
+
   return (
     <div className='h-[100px] flex bg-main-dark-blue rounded-t-2xl z-0'>
       <div
-        style={{ width: '50%' }}
-        className='bg-green-bg text-center rounded-t-2xl'
-        onClick={handleViewDetail}
+        style={{
+          width: '50%',
+          transform:
+            selectedTab === 'detail' ? 'translateY(-10px)' : 'translateY(0)',
+        }}
+        className='bg-green-bg text-center rounded-t-2xl cursor-pointer'
+        onClick={handleDetailClick}
       >
         <p className='text-2xl' style={{ transform: 'translateY(10px)' }}>
           상세 페이지
         </p>
       </div>
       <div
-        style={{ width: '50%' }}
-        className='bg-black text-center rounded-t-2xl'
-        onClick={handleViewVerfication}
+        style={{
+          width: '50%',
+          transform:
+            selectedTab === 'verification'
+              ? 'translateY(-10px)'
+              : 'translateY(0)',
+        }}
+        className='bg-black text-center rounded-t-2xl cursor-pointer'
+        onClick={handleVerificationClick}
       >
         <p className='text-2xl' style={{ transform: 'translateY(10px)' }}>
           인증 페이지

--- a/src/components/habits/TitleAndAuthorInfo.js
+++ b/src/components/habits/TitleAndAuthorInfo.js
@@ -1,6 +1,6 @@
 const TitleAndAuthorInfo = ({ title, groupName, creator }) => {
   return (
-    <div className='h-[100px]'>
+    <div className='h-[100px] mt-12'>
       <h1 className='text-3xl text-center font-bold flex-1 mt-4'>{title}</h1>
       <div className='mb-4 mr-8 font-bold text-right'>
         <p>{groupName ? groupName : '비공개'}</p>

--- a/src/components/habits/TitleAndAuthorInfo.js
+++ b/src/components/habits/TitleAndAuthorInfo.js
@@ -1,6 +1,6 @@
 const TitleAndAuthorInfo = ({ title, groupName, creator }) => {
   return (
-    <div className='h-[100px] mt-12'>
+    <div className='h-[100px]'>
       <h1 className='text-3xl text-center font-bold flex-1 mt-4'>{title}</h1>
       <div className='mb-4 mr-8 font-bold text-right'>
         <p>{groupName ? groupName : '비공개'}</p>

--- a/src/components/habits/habitList/HabitItem.js
+++ b/src/components/habits/habitList/HabitItem.js
@@ -2,11 +2,12 @@ import axios from 'axios';
 import { useDispatch } from 'react-redux';
 import { setHabitDetail } from '../../../redux/habitSlice';
 
-const HabitItem = ({ habitInfo }) => {
+const HabitItem = ({ habitInfo, isSelected, onSelect }) => {
   const dispatch = useDispatch();
 
   const onClickHandler = async () => {
     try {
+      onSelect();
       const response = await axios.get(
         `${process.env.REACT_APP_SERVER_DOMAIN}/api/habit/${habitInfo._id}`,
       );
@@ -24,7 +25,11 @@ const HabitItem = ({ habitInfo }) => {
   };
 
   return (
-    <div className='bg-main-bg text-white p-4 m-2 rounded-lg hover:bg-dark-green-bg transform hover:scale-95 hover: transition duration-200 ease-in-out'>
+    <div
+      className={`bg-main-bg text-white p-4 m-2 rounded-lg hover:bg-dark-green-bg transform hover:scale-95 transition duration-200 ease-in-out ${
+        isSelected ? 'shadow-green' : ''
+      }`}
+    >
       <button className='w-full' onClick={onClickHandler}>
         <p className='text-sm text-left'>
           {habitInfo.startTime} ~ {habitInfo.endTime}

--- a/src/components/habits/habitList/HabitList.js
+++ b/src/components/habits/habitList/HabitList.js
@@ -5,6 +5,7 @@ import GroupInviteButton from './GroupInviteButton';
 import HabbitCreateButton from './HabitCreateButton';
 
 function HabitList({ dailyHabits }) {
+  const [selectedHabitId, setSelectedHabitId] = useState(null);
   const currentUrl = useLocation().pathname;
   const currentPage = currentUrl.split('/')[1]; // 'my-habit' or 'group'
   const members = Object.keys(dailyHabits.data);
@@ -14,7 +15,7 @@ function HabitList({ dailyHabits }) {
   const habits = dailyHabits.data[selectedMemberNickname];
   const handleOnchange = (e) => setSelectedMemberNickname(e.target.value);
 
-  const sortedHabits = habits.sort((a, b) => {
+  const sortedHabits = habits?.sort((a, b) => {
     return a.startTime.localeCompare(b.startTime);
   });
 
@@ -37,7 +38,7 @@ function HabitList({ dailyHabits }) {
               className='bg-green-bg'
               style={{ transform: 'translateY(5px)' }}
             >
-              {members.map((member) => (
+              {members?.map((member) => (
                 <option key={member} value={member}>
                   {member}
                 </option>
@@ -49,8 +50,15 @@ function HabitList({ dailyHabits }) {
       </div>
       <div className='h-[70vh] overflow-hidden top-12 bg-dark-blue-bg rounded-3xl z-10 relative p-3'>
         <div className='h-full overflow-y-auto pt-4 custom-scrollbar'>
-          {sortedHabits.map((habit) => {
-            return <HabitItem key={habit._id} habitInfo={habit}></HabitItem>;
+          {sortedHabits?.map((habit) => {
+            return (
+              <HabitItem
+                key={habit._id}
+                habitInfo={habit}
+                isSelected={selectedHabitId === habit._id}
+                onSelect={() => setSelectedHabitId(habit._id)}
+              ></HabitItem>
+            );
           })}
         </div>
         {currentPage === 'my-habit' && (

--- a/src/components/habits/habitList/HabitList.js
+++ b/src/components/habits/habitList/HabitList.js
@@ -7,7 +7,7 @@ import HabbitCreateButton from './HabitCreateButton';
 function HabitList({ dailyHabits }) {
   const [selectedHabitId, setSelectedHabitId] = useState(null);
   const currentUrl = useLocation().pathname;
-  const currentPage = currentUrl.split('/')[1];
+  const currentPage = currentUrl.split('/')[1]; // 'my-habit' or 'group'
   const members = Object.keys(dailyHabits.data);
   const [selectedMemberNickname, setSelectedMemberNickname] = useState(
     members[0],

--- a/src/components/habits/habitList/HabitList.js
+++ b/src/components/habits/habitList/HabitList.js
@@ -7,7 +7,7 @@ import HabbitCreateButton from './HabitCreateButton';
 function HabitList({ dailyHabits }) {
   const [selectedHabitId, setSelectedHabitId] = useState(null);
   const currentUrl = useLocation().pathname;
-  const currentPage = currentUrl.split('/')[1]; // 'my-habit' or 'group'
+  const currentPage = currentUrl.split('/')[1];
   const members = Object.keys(dailyHabits.data);
   const [selectedMemberNickname, setSelectedMemberNickname] = useState(
     members[0],

--- a/src/hooks/useFetchHabitData.js
+++ b/src/hooks/useFetchHabitData.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import habitGetAPI from '../services/api/habitGet';
+
+export const useFetchHabitData = (habitId, isEdit) => {
+  const [habitData, setHabitData] = useState(null);
+
+  useEffect(() => {
+    const fetchHabitData = async () => {
+      try {
+        const response = await habitGetAPI(habitId);
+        setHabitData(response.data);
+      } catch (error) {
+        console.error('Error fetching habit:', error);
+      }
+    };
+
+    if (isEdit) {
+      fetchHabitData();
+    }
+  }, [habitId, isEdit]);
+
+  return habitData;
+};

--- a/src/hooks/useFetchHabitData.js
+++ b/src/hooks/useFetchHabitData.js
@@ -8,6 +8,7 @@ export const useFetchHabitData = (habitId, isEdit) => {
     const fetchHabitData = async () => {
       try {
         const response = await habitGetAPI(habitId);
+
         setHabitData(response.data);
       } catch (error) {
         console.error('Error fetching habit:', error);

--- a/src/hooks/useFetchUserData.js
+++ b/src/hooks/useFetchUserData.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import userGetAPI from '../services/api/userGet';
+
+export const useFetchUserData = (userId) => {
+  const [groupList, setGroupList] = useState([]);
+
+  useEffect(() => {
+    const fetchUserData = async () => {
+      try {
+        const response = await userGetAPI(userId, 'group', true);
+        const groupOptions = response.groups.map((group) => ({
+          groupId: group._id,
+          groupName: group.groupName,
+        }));
+
+        setGroupList(groupOptions);
+      } catch (error) {
+        console.error('Error fetching user data:', error);
+      }
+    };
+
+    fetchUserData();
+  }, [userId]);
+
+  return groupList;
+};

--- a/src/hooks/useHandleSubmit.js
+++ b/src/hooks/useHandleSubmit.js
@@ -8,6 +8,7 @@ export const useHandleSubmit = (
   navigate,
   nickname,
   isEdit = false,
+  habitId,
 ) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [message, setMessage] = useState(null);
@@ -20,7 +21,11 @@ export const useHandleSubmit = (
       return;
     }
 
-    setMessage('습관 생성이 완료되었습니다. 나의 습관 관리 페이지로 이동합니다.');
+    const successMessage = isEdit
+      ? '습관 수정이 완료되었습니다. 나의 습관 관리 페이지로 이동합니다.'
+      : '습관 생성이 완료되었습니다. 나의 습관 관리 페이지로 이동합니다.';
+
+    setMessage(successMessage);
     setMessageType('success');
 
     setTimeout(() => {
@@ -36,12 +41,13 @@ export const useHandleSubmit = (
     setIsSubmitting(true);
 
     const habitData = createHabitData(formData, userId);
+
     try {
       let response;
 
       if (isEdit) {
         response = await axios.patch(
-          `${process.env.REACT_APP_SERVER_DOMAIN}/api/habit/${habitData.habitId}`,
+          `${process.env.REACT_APP_SERVER_DOMAIN}/api/habit/${habitId}`,
           habitData,
         );
         handleResponse(response);

--- a/src/hooks/useHandleSubmit.js
+++ b/src/hooks/useHandleSubmit.js
@@ -21,9 +21,9 @@ export const useHandleSubmit = (
       return;
     }
 
-    const successMessage = isEdit
-      ? '습관 수정이 완료되었습니다. 나의 습관 관리 페이지로 이동합니다.'
-      : '습관 생성이 완료되었습니다. 나의 습관 관리 페이지로 이동합니다.';
+    const successMessage = `습관 ${
+      isEdit ? '수정' : '생성'
+    }이 완료되었습니다. 나의 습관 관리 페이지로 이동합니다.`;
 
     setMessage(successMessage);
     setMessageType('success');

--- a/src/hooks/useHandleSubmit.js
+++ b/src/hooks/useHandleSubmit.js
@@ -53,13 +53,12 @@ export const useHandleSubmit = (
         handleResponse(response);
 
         return;
+      } else {
+        response = await axios.post(
+          `${process.env.REACT_APP_SERVER_DOMAIN}/api/habit`,
+          habitData,
+        );
       }
-
-      response = await axios.post(
-        `${process.env.REACT_APP_SERVER_DOMAIN}/api/habit`,
-        habitData,
-      );
-
       handleResponse(response);
     } catch (error) {
       const errorMsg =

--- a/src/pages/CreateHabit/forms/GroupForm.js
+++ b/src/pages/CreateHabit/forms/GroupForm.js
@@ -1,14 +1,20 @@
 import React from 'react';
 import Tooltip from '../utils/Tooltip';
 
-const GroupForm = ({ sharedGroup, setSharedGroup, groupOptions }) => {
+const GroupForm = ({ sharedGroup, setSharedGroup, groupOptions, isEdit }) => {
   const tooltipText = (
     <>
       <div className='mb-2'>
         <span className='text-black'>그룹 선택이란?</span>
       </div>
       <div className='mb-2'>
-        <span className='text-green-500'>그룹 미선택 시</span>
+        <span className='text-red-500'>
+          그룹은 생성할 때 선택한 그룹 설정(또는 비공개 설정)을 이후 수정할 수
+          없으므로 신중하게 선택하시기 바랍니다.
+        </span>
+      </div>
+      <div className='mb-2'>
+        <span className='text-blue-500'>그룹 미선택 시</span>
         <div>
           비공개 처리 되며, 나의 습관 관리 페이지에서 본인만 확인 가능한 습관이
           생성됩니다.
@@ -33,6 +39,7 @@ const GroupForm = ({ sharedGroup, setSharedGroup, groupOptions }) => {
       <label className='relative'>
         그룹 선택
         <span className='ml-2 inline-block group cursor-pointer'>
+          <span className='text-red-500'> (생성 후 수정 불가) </span>
           <span className='bg-gray-200 rounded-full pr-2 pl-2'>?</span>
           <Tooltip text={tooltipText} />
         </span>
@@ -40,9 +47,12 @@ const GroupForm = ({ sharedGroup, setSharedGroup, groupOptions }) => {
 
       <div className='mb-4'>
         <select
-          className='w-full p-2 border rounded'
+          className={`w-full p-2 border rounded ${
+            isEdit ? 'bg-gray-200 cursor-not-allowed' : ''
+          }`}
           value={sharedGroup || ''}
           onChange={handleSharedGroupChange}
+          disabled={isEdit}
         >
           <option value=''>
             초대된 그룹만 선택 가능합니다(미선택 시 비공개 처리됩니다)

--- a/src/pages/CreateHabit/index.js
+++ b/src/pages/CreateHabit/index.js
@@ -64,11 +64,8 @@ const CreateOrEditHabit = ({ isEdit = false }) => {
       setPenalty(habitData.penalty);
       setMinApprovalCount(habitData.minApprovalCount);
 
-      if (habitData.sharedGroup === null) {
-        setSharedGroup('');
-      } else {
-        setSharedGroup(habitData.sharedGroup._id);
-      }
+      const group = habitData.sharedGroup ? habitData.sharedGroup._id : '';
+      setSharedGroup(group);
     }
   }, [habitData]);
 

--- a/src/pages/CreateHabit/index.js
+++ b/src/pages/CreateHabit/index.js
@@ -24,6 +24,7 @@ const token = localStorage.getItem('accessToken');
 const userId = getUserIdFromToken(token);
 
 const CreateOrEditHabit = ({ isEdit = false }) => {
+  const navigate = useNavigate();
   const today = new Date().toISOString().split('T')[0];
   const { habitId } = useParams();
   const [habitTitle, setHabitTitle] = useState('');
@@ -39,9 +40,7 @@ const CreateOrEditHabit = ({ isEdit = false }) => {
   const [sharedGroup, setSharedGroup] = useState(null);
   const { validationMessage, validateForm } = useValidation();
   const [groupList, setGroupList] = useState([]);
-  const navigate = useNavigate();
   const nickname = useFetchUserInfo(userId);
-
   const habitData = useFetchHabitData(habitId, isEdit);
   const fetchedGroupList = useFetchUserData(userId);
 

--- a/src/pages/CreateHabit/index.js
+++ b/src/pages/CreateHabit/index.js
@@ -64,7 +64,12 @@ const CreateOrEditHabit = ({ isEdit = false }) => {
 
       setPenalty(habitData.penalty);
       setMinApprovalCount(habitData.minApprovalCount);
-      setSharedGroup(habitData.sharedGroup._id);
+
+      if (habitData.sharedGroup === null) {
+        setSharedGroup('');
+      } else {
+        setSharedGroup(habitData.sharedGroup._id);
+      }
     }
   }, [habitData]);
 

--- a/src/pages/CreateHabit/index.js
+++ b/src/pages/CreateHabit/index.js
@@ -95,10 +95,12 @@ const CreateOrEditHabit = ({ isEdit = false }) => {
     navigate,
     nickname,
     isEdit,
+    habitId,
   );
 
   const handleFormSubmit = (e) => {
     e.preventDefault();
+
     handleSubmit({
       habitTitle,
       habitContent,
@@ -155,6 +157,7 @@ const CreateOrEditHabit = ({ isEdit = false }) => {
               sharedGroup={sharedGroup}
               setSharedGroup={setSharedGroup}
               groupOptions={groupList}
+              isEdit={isEdit}
             />
 
             <PenaltyForm penalty={penalty} setPenalty={setPenalty} />

--- a/src/pages/CreateHabit/utils/calculateTimeDetails.js
+++ b/src/pages/CreateHabit/utils/calculateTimeDetails.js
@@ -1,0 +1,24 @@
+const calculateTimeDetails = (startTime, endTime) => {
+  const [startHour, startMinute] = startTime.split(':').map(Number);
+  const [endHour, endMinute] = endTime.split(':').map(Number);
+
+  const timePeriod = startHour < 12 ? 'AM' : 'PM';
+
+  const hour = startHour % 12 === 0 ? 12 : startHour % 12;
+
+  const minute = startMinute;
+
+  const startTotalMinutes = startHour * 60 + startMinute;
+  const endTotalMinutes = endHour * 60 + endMinute;
+
+  let duration = endTotalMinutes - startTotalMinutes;
+
+  return {
+    timePeriod,
+    hour,
+    minute,
+    duration,
+  };
+};
+
+export default calculateTimeDetails;

--- a/src/pages/Group/index.js
+++ b/src/pages/Group/index.js
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
+import getGroup from '../../services/api/groupGet';
 import { clearHabitDetail } from '../../redux/habitSlice';
 import { useDailyHabits } from '../../hooks/useDailyHabits';
 import getCurrentDate from '../../utils/getCurrentDate';
@@ -10,22 +11,40 @@ import HabitDetailAndVerification from '../../components/habits/HabitDetailAndVe
 function Group() {
   const dispatch = useDispatch();
   const { groupId } = useParams('groupId');
-
   const currentDate = getCurrentDate();
+  const [groupInfo, setGroupInfo] = useState(null);
+
   const { dailyHabits, loading, error } = useDailyHabits(
     `${process.env.REACT_APP_SERVER_DOMAIN}/api/group/${groupId}/habitList?date=${currentDate}`,
   );
 
+  const fetchGroupInfo = async () => {
+    try {
+      dispatch(clearHabitDetail());
+
+      const data = await getGroup(groupId);
+      setGroupInfo(data);
+    } catch (error) {
+      console.error('Error fetching group info', error);
+    }
+  };
+
   useEffect(() => {
-    dispatch(clearHabitDetail());
+    fetchGroupInfo();
   }, [groupId, dispatch]);
 
   if (loading) return <div>Loading...</div>;
   if (error) return <div>Error: {error.message}</div>;
 
   return (
-    <section className='min-h-screen flex-1  flex flex-col bg-main-bg text-white bg-vignette'>
-      <article className='flex mx-auto mt-28'>
+    <section className='min-h-screen flex flex-col bg-main-bg text-white'>
+      <div className='text-center pt-20 mr-20'>
+        <div className='inline-block'>
+          <h1 className='text-2xl'>{groupInfo.group.groupName}</h1>
+          <div className='w-full h-[2px] bg-white mt-2'></div>
+        </div>
+      </div>
+      <article className='flex mx-auto mt-10'>
         <HabitList dailyHabits={dailyHabits} />
         <HabitDetailAndVerification />
       </article>

--- a/src/pages/Group/index.js
+++ b/src/pages/Group/index.js
@@ -23,6 +23,7 @@ function Group() {
       dispatch(clearHabitDetail());
 
       const data = await getGroup(groupId);
+
       setGroupInfo(data);
     } catch (error) {
       console.error('Error fetching group info', error);

--- a/src/services/api/groupGet.js
+++ b/src/services/api/groupGet.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+export const getGroup = async (groupId) => {
+  try {
+    const response = await axios.get(
+      `${process.env.REACT_APP_SERVER_DOMAIN}/api/group/${groupId}`,
+    );
+
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
+export default getGroup;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,6 +32,9 @@ module.exports = {
         customRed: '#FF0000',
         darkGray: '#C0C0C3',
       },
+      boxShadow: {
+        green: '0 0 8px 3px rgba(0, 255, 0, 0.5)',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 📝 PR 목적

Feature 습관 관리 및 수정 페이지

## 📑 작업 내용

- [x]  나의 습관 페이지 url `/my-habit/{nickname}`
- [x]  그룹 페이지 url `/group/{groupId}`
- [x]  그룹 페이지 이동 시, 그룹의 그룹네임 상단에 표시
- [x]  습관 목록에서 습관 아이템 클릭시 클릭된 아이템에 테두리 표시
- [x]  나의 습관 관리 페이지에서는 수정/삭제 버튼 보이기
- [x]  습관 수정 페이지 url 설정 및 수정 api 연결 
- [x]  습관 삭제 api 연결
- [x]  습관 수정 시 그룹은 수정할 수 없도록 수정
- [x]  왓쳐 리스트 중앙 정렬 및 status notTimeYet 및 inProgress일 때에만 왓쳐 등록/해제 가능하도록 수정 
- [x]  이외의 status일 경우 왓쳐 리스트와 텍스트('인증 탭을 확인하세요')만 보여지는 상태로 수정

[습관 상세 아이템 테두리]

https://github.com/Last-Survivors-3-8/Watcher-Habit-Client/assets/133510836/77125672-6e43-48f9-b986-783ac0c7d39b


[습관 상태별 왓쳐]
내 습관에서 등록된 왓쳐가 없을 때
<img width="434" alt="스크린샷 2023-09-20 오후 7 36 41" src="https://github.com/Last-Survivors-3-8/Watcher-Habit-Client/assets/133510836/3fb40c12-8bf6-4a9e-9bbe-5749a92a1c8e">

내 습관에서 비공개인 습관일 때
<img width="428" alt="스크린샷 2023-09-20 오후 7 39 57" src="https://github.com/Last-Survivors-3-8/Watcher-Habit-Client/assets/133510836/c8eef19d-f59f-4582-b2f2-f21c8b25756a">

왓쳐가 있으면서 status가 notTimeYet 및 inProgress가 아닐 때
<img width="430" alt="스크린샷 2023-09-20 오후 7 36 32" src="https://github.com/Last-Survivors-3-8/Watcher-Habit-Client/assets/133510836/b25d0ba5-aa4e-474d-9bfd-fa447aa70135">

왓쳐가 없으면서 status가 notTimeYet 및 inProgress가 아닐 때
<img width="437" alt="스크린샷 2023-09-20 오후 7 36 35" src="https://github.com/Last-Survivors-3-8/Watcher-Habit-Client/assets/133510836/37881aad-7ba5-493b-a5c5-475b35bea343">

나의 습관 관리 페이지이면서 내가 작성한 게시글일 때 - 수정 삭제 버튼 렌더링
<img width="487" alt="스크린샷 2023-09-20 오후 8 20 26" src="https://github.com/Last-Survivors-3-8/Watcher-Habit-Client/assets/133510836/e435cf8b-9bcf-427c-8bfd-4c46dd7c8e25">

## 🚧 주의 사항

버그 발견되면 바로 말씀해주시면 감사하겠습니다.